### PR TITLE
[FAL-2409] fix: update PyGitHub to a version that doesn't use use_2to3

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -14,7 +14,7 @@ GitPython
 google-api-python-client==1.7.3
 jenkinsapi==0.3.3
 lxml
-PyGithub==1.43.8
+PyGithub==1.44.1
 pymongo==3.5.1
 pytz==2016.10
 pyyaml==5.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -38,7 +38,7 @@ pbr==5.5.1                # via stevedore
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
 pycparser==2.20           # via cffi
-pygithub==1.43.8          # via -r requirements/base.in
+pygithub==1.44.1          # via -r requirements/base.in
 pyjwt==1.7.1              # via edx-rest-api-client, pygithub
 pymongo==3.5.1            # via -r requirements/base.in, edx-opaque-keys
 python-dateutil==2.8.1    # via freezegun
@@ -50,7 +50,7 @@ rsa==4.6                  # via google-auth
 sailthru-client==2.3.5    # via -r requirements/base.in
 simple-salesforce==1.10.1  # via -r requirements/base.in
 simplejson==3.17.2        # via sailthru-client
-six==1.15.0               # via -r requirements/base.in, atlassian-python-api, cryptography, edx-opaque-keys, freezegun, google-api-python-client, google-auth, google-auth-httplib2, jsonlines, python-dateutil, stevedore, validators, yagocd
+six==1.15.0               # via -r requirements/base.in, atlassian-python-api, cryptography, edx-opaque-keys, freezegun, google-api-python-client, google-auth, google-auth-httplib2, jsonlines, pygithub, python-dateutil, stevedore, validators, yagocd
 slumber==0.7.1            # via edx-rest-api-client
 smmap==3.0.4              # via gitdb
 stevedore==1.32.0         # via edx-opaque-keys


### PR DESCRIPTION
This will fix the errors when trying to install PyGitHub using newer
versions of setuptools that don't support use_2to3.